### PR TITLE
Reduce CPU load in idle state

### DIFF
--- a/main.py
+++ b/main.py
@@ -119,6 +119,7 @@ def start():
 				rf.close()
 				inp = None
 				alexa()
+                                GPIO.wait_for_edge(button, GPIO.FALLING)
 			elif val == 0:
 				GPIO.output(25, GPIO.HIGH)
 				inp = alsaaudio.PCM(alsaaudio.PCM_CAPTURE, alsaaudio.PCM_NORMAL, device)


### PR DESCRIPTION
Wait for foalling GPIO-edge after handling the alexa request,
thus reducing CPU usage as program doesn't activly spin waiting
for the GPIO to go low.